### PR TITLE
Front end: links and tooltips for segments

### DIFF
--- a/front-end/nott-missing-map/package-lock.json
+++ b/front-end/nott-missing-map/package-lock.json
@@ -7400,6 +7400,14 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "json2yaml": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/json2yaml/-/json2yaml-1.1.0.tgz",
+      "integrity": "sha1-VBTZB/mBZYa4DFE+wuOusquBmmw=",
+      "requires": {
+        "remedial": "1.x"
+      }
+    },
     "json3": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
@@ -9805,6 +9813,11 @@
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true
+    },
+    "remedial": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
+      "integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg=="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",

--- a/front-end/nott-missing-map/package-lock.json
+++ b/front-end/nott-missing-map/package-lock.json
@@ -6377,6 +6377,11 @@
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
+    "gsap": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-2.1.2.tgz",
+      "integrity": "sha512-7saMzK2HQ3OD4/hbygtkh0uAK8LUqcom6abL4YqGttyxAQdEvywQOw5VK3obKQ7GaLU8KhszArKJPxIKe8mbvg=="
+    },
     "gzip-size": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.0.tgz",

--- a/front-end/nott-missing-map/package-lock.json
+++ b/front-end/nott-missing-map/package-lock.json
@@ -6377,11 +6377,6 @@
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
-    "gsap": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/gsap/-/gsap-2.1.2.tgz",
-      "integrity": "sha512-7saMzK2HQ3OD4/hbygtkh0uAK8LUqcom6abL4YqGttyxAQdEvywQOw5VK3obKQ7GaLU8KhszArKJPxIKe8mbvg=="
-    },
     "gzip-size": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.0.tgz",

--- a/front-end/nott-missing-map/package.json
+++ b/front-end/nott-missing-map/package.json
@@ -13,6 +13,7 @@
     "file-saver": "^2.0.1",
     "image-comparison": "^2.0.4",
     "jimp": "^0.6.1",
+    "json2yaml": "^1.1.0",
     "jszip": "^3.2.1",
     "lodash": "^4.17.11",
     "vue": "^2.6.6",

--- a/front-end/nott-missing-map/package.json
+++ b/front-end/nott-missing-map/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "axios": "^0.18.0",
     "file-saver": "^2.0.1",
+    "gsap": "^2.1.2",
     "image-comparison": "^2.0.4",
     "jimp": "^0.6.1",
     "json2yaml": "^1.1.0",

--- a/front-end/nott-missing-map/package.json
+++ b/front-end/nott-missing-map/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "axios": "^0.18.0",
     "file-saver": "^2.0.1",
-    "gsap": "^2.1.2",
     "image-comparison": "^2.0.4",
     "jimp": "^0.6.1",
     "json2yaml": "^1.1.0",

--- a/front-end/nott-missing-map/src/App.vue
+++ b/front-end/nott-missing-map/src/App.vue
@@ -197,19 +197,19 @@
                 <v-dialog v-model="previewImg.on" content-class="prevDialog" ref="prevDialog">
                   <v-card  v-if="previewImg.on" height="100%">
                     <v-layout class="ma-0 pa-0" column style="height: 100%">
-                      <v-flex d-flex>
+                      <v-flex d-flex shrink>
                         <v-card-title class="title grey lighten-2 pa-3" >
                           <!-- Take the file name as the title of popup -->
                           {{previewImg.reportCard.img.file.name}}
                         </v-card-title>
                       </v-flex>
 
-                      <v-flex d-flex fill-height>
+                      <v-flex d-flex grow>
                         <v-card-text class="">
                           <ImgPreview :reportCard="previewImg.reportCard"/>
                         </v-card-text>
                       </v-flex>
-                      <v-flex d-flex>
+                      <v-flex d-flex shrink>
                         <v-card-actions>
                           <v-spacer></v-spacer><!-- align the close button right  -->
                           <v-btn small color="primary" flat @click="previewImg.on = false">
@@ -478,6 +478,7 @@ export default {
 
 .prevDialog {
   width: 90%;
+  overflow: hidden;
   height: 80vh;
 }
 

--- a/front-end/nott-missing-map/src/App.vue
+++ b/front-end/nott-missing-map/src/App.vue
@@ -191,28 +191,34 @@
               <br class="hidden-sm-and-up">
               <br class="hidden-sm-and-up">
             </v-container>
-            <!-- popup in report page -->
+            <!-- popup in report page (image preview) -->
             <template>
               <div class="text-xs-center">
-                <v-dialog v-model="previewImg.on" width="1000">
-                  <v-card  v-if="previewImg.on">
-                    <v-card-title class="title grey lighten-2 pa-3" >
-                      <!-- Take the file name as the title of popup -->
-                      {{previewImg.reportCard.img.file.name}}
-                    </v-card-title>
+                <v-dialog v-model="previewImg.on" content-class="prevDialog" ref="prevDialog">
+                  <v-card  v-if="previewImg.on" height="100%">
+                    <v-layout class="ma-0 pa-0" column style="height: 100%">
+                      <v-flex d-flex>
+                        <v-card-title class="title grey lighten-2 pa-3" >
+                          <!-- Take the file name as the title of popup -->
+                          {{previewImg.reportCard.img.file.name}}
+                        </v-card-title>
+                      </v-flex>
 
-                    <v-card-text>
-                      <ImgPreview :reportCard="previewImg.reportCard"/>
-                    </v-card-text>
+                      <v-flex d-flex fill-height>
+                        <v-card-text class="">
+                          <ImgPreview :reportCard="previewImg.reportCard"/>
+                        </v-card-text>
+                      </v-flex>
+                      <v-flex d-flex>
+                        <v-card-actions>
+                          <v-spacer></v-spacer><!-- align the close button right  -->
+                          <v-btn small color="primary" flat @click="previewImg.on = false">
+                            Close
+                          </v-btn>
+                        </v-card-actions>
+                      </v-flex>
+                    </v-layout>
 
-                    <v-divider></v-divider> <!-- align the close button right  -->
-
-                    <v-card-actions>
-                      <v-spacer></v-spacer>
-                      <v-btn small color="primary" flat @click="previewImg.on = false">
-                        Close
-                      </v-btn>
-                    </v-card-actions>
                   </v-card>
                 </v-dialog>
               </div>
@@ -468,6 +474,11 @@ export default {
    left: 0;
    z-index: 2;
    flex-wrap: wrap-reverse;
+}
+
+.prevDialog {
+  width: 90%;
+  height: 80vh;
 }
 
 </style>

--- a/front-end/nott-missing-map/src/App.vue
+++ b/front-end/nott-missing-map/src/App.vue
@@ -145,14 +145,6 @@
 
               <v-flex pa-0 shrink text-xs-left>
                 <v-btn color="info" :small="$vuetify.breakpoint.smAndDown"
-                  @click="download_report"
-                >
-                  <v-icon class="hidden-sm-and-down">arrow_downward</v-icon>
-                  Download Report
-                  <template v-slot:loader><span>Compressing...</span></template>
-                </v-btn>
-
-                <v-btn color="info" :small="$vuetify.breakpoint.smAndDown"
                   :loading="zipping" :disabled="zipping"
                   @click="download_all"
                 >
@@ -256,11 +248,6 @@ export default {
       [...this.$refs.report_card].forEach((child) => {
         child.show = expand; // eslint-disable-line no-param-reassign
       });
-    },
-
-    // DOWNLOAD REPORT button handler
-    download_report() {
-      saveAs(this.reportBlob, 'report.txt');
     },
 
     // DOWNLOAD ALL button handler

--- a/front-end/nott-missing-map/src/App.vue
+++ b/front-end/nott-missing-map/src/App.vue
@@ -7,7 +7,7 @@
           <!-- The top tool bar -->
           <v-card>
             <v-toolbar app fixed style="z-index: 999;">
-              <v-btn icon v-on:click="goHome()" :disabled="uploading || zipping">
+              <v-btn icon @click="goHome()" :disabled="uploading || zipping">
                 <v-icon>home</v-icon>
               </v-btn>
               <v-flex shrink>
@@ -28,6 +28,105 @@
                 </v-alert>
               </v-flex>
               <v-spacer></v-spacer>
+
+              <!-- Help dialog -->
+              <v-dialog v-model="helpDialog" width="90%">
+                <template v-slot:activator="{ on }">
+                  <v-btn icon v-on="on">
+                    <v-icon>help</v-icon>
+                  </v-btn>
+                </template>
+                <v-card>
+                  <v-card-title class="grey lighten-2 py-2">
+                    <span class="headline">Instructions</span>
+                    <v-spacer />
+                    <v-btn flat color="info" class="px-0"
+                      href="http://tinyurl.com/yxzvkmd9" target="_blank"
+                    >user manual</v-btn>
+                    <v-btn flat color="info" class="px-0 hidden-sm-and-down"
+                      href="http://tinyurl.com/y6qjhse3" target="_blank"
+                    >Software documentation</v-btn>
+                    <v-btn flat color="info" class="mx-0 hidden-xs-only"
+                      href="https://github.com/Carbsta/NottsMissingMaps" target="_blank"
+                    >
+                      <img style="display: inline; width: 20px;" class="ma-1"
+                        src="https://github.githubassets.com/favicon.ico"/>
+                      <span style="text-transform: none; position: relative; top:2px">Star</span>
+                    </v-btn>
+
+                  </v-card-title>
+                  <v-card-text class="text-xs-left">
+                    <h1 class="title mb-1">Upload Images</h1>
+                    <h2 class="subheading">Upload</h2>
+                    <p class="body-2">
+                      You can drag satellite images into the box, or click on
+                      it to choose file(s) from your filesystem.Images that you
+                      choose appear on the right-hand side on report cards. The
+                      name and size are shown to the right of the images.
+                    </p>
+
+                    <h2 class="subheading">Dismiss</h2>
+                    <p class="body-2">
+                      You can scroll through these cards if you have uploaded
+                      many images, and clicking on the dismiss button will remove
+                      that image.
+                    </p>
+                    <h2 class="subheading">Format error</h2>
+                    <p class="body-2">
+                      If the format of the file is not image, you will get a
+                      warning.
+                    </p>
+                    <h2 class="subheading">Submit</h2>
+                    <p class="body-2">
+                      Click “Submit”, classify these images that you uploaded.
+                      Once the progress indicator reaches 100 percent, you will
+                      be taken to the results page automatically.
+                    </p>
+
+                    <h1 class="title mb-1">Final Result</h1>
+                    <p class="body-2">
+                      The results of the classification are displayed as report cards.
+                    </p>
+                    <p class="body-2">
+                      You can click on the images to move the heatmap with the little
+                      slider, or click on the "preview" button to view a larger version
+                      of the image.
+                    </p>
+                    <p class="body-2">
+                      You can see the overall habitation score underneath the name of the
+                      image, this score is the maximum habitation score from all of the segments.
+                      It is a scale from 0 to 1, representing the percentage of confidence.
+                      Also, the colour coded tags tell you which classes have a segment with a
+                      score over 0.8. To view information about each segment in detail,
+                      click on the "details" button of a card, or click on the "expand all"
+                      button to view all cards at once.
+                    </p>
+                    <p class="body-2">
+                      The segments are numbered in ascending order, with segment 1 being
+                      the top left segment, going left to right. Each score represents
+                      the confidence in the image belonging to each class, from 0 to 1.
+                      1 being 100 percent confidence. Click "collapse" or "collapse all"
+                      to hide these details again.
+                    </p>
+                    <p class="body-2">
+                      The download button downloads the masked version of the image,
+                      and the download all button downloads a zip archive containing
+                      all of these images.
+                    </p>
+                    <p class="body-2">
+                      Enjoy using the website!
+                    </p>
+
+                  </v-card-text>
+                  <v-divider></v-divider>
+                  <v-card-actions>
+                    <v-spacer></v-spacer>
+                    <v-btn color="primary" flat @click="helpDialog = false">
+                      Close
+                    </v-btn>
+                  </v-card-actions>
+                </v-card>
+              </v-dialog>
             </v-toolbar>
           </v-card>
 
@@ -123,7 +222,7 @@
           <!-- Bottom buttons -->
           <v-layout row class="fab-container" ma-3>
             <!-- submit button on uploading page -->
-            <v-btn v-if="uploadingPage" color="info" v-on:click="submitImg" :loading="uploading">
+            <v-btn v-if="uploadingPage" color="info" @click="submitImg" :loading="uploading">
               Submit
             </v-btn>
 
@@ -131,13 +230,13 @@
             <template v-else>
               <v-flex pa-0 shrink text-xs-left>
                 <v-btn color="info" :small="$vuetify.breakpoint.smAndDown"
-                  v-on:click="expand_all(true)"
+                  @click="expand_all(true)"
                 >
                   <v-icon class="hidden-sm-and-down">unfold_more</v-icon> Expand All
                 </v-btn>
 
                 <v-btn color="info" :small="$vuetify.breakpoint.smAndDown"
-                  v-on:click="expand_all(false)"
+                  @click="expand_all(false)"
                 >
                   <v-icon class="hidden-sm-and-down">unfold_less</v-icon> Collapse All
                 </v-btn>
@@ -183,6 +282,7 @@ export default {
       zipping: false,
       previewImg: { reportCard: undefined, on: false },
       progress: { data: 0, max: 0 },
+      helpDialog: false,
     };
   },
 

--- a/front-end/nott-missing-map/src/App.vue
+++ b/front-end/nott-missing-map/src/App.vue
@@ -165,7 +165,6 @@
 import JSZip from 'jszip';
 import { saveAs } from 'file-saver';
 import { sliceNum, progressWeight } from '@src/config';
-import { stringify as json2yml } from 'json2yaml';
 import DragDropBox from './components/DragDropBox.vue';
 import PreviewCard from './components/PreviewCard.vue';
 import ReportCard from './components/ReportCard.vue';
@@ -255,29 +254,17 @@ export default {
     download_all() {
       this.zipping = true;
       const zip = new JSZip();
-      const promiseBlob = [...this.$refs.report_card]
-        .map(card => card.maskedImgBlob);
-      Promise.all(promiseBlob).then((blobs) => {
-        blobs
-          .forEach((x, i) => {
-            zip.file(x.name, x.blob);
-            // Add the user-friendly yaml report (looks like normal text)
-            zip.file(
-              `${x.name}_report.txt`,
-              new Blob([json2yml(this.reportObjs[i])], { type: 'text/plain' }),
-            );
-            // Add the nerd-specific report.
-            zip.file(
-              `${x.name}_report.json`,
-              new Blob([JSON.stringify(this.reportObjs[i], null, 2)], { type: 'text/plain' }),
-            );
+      [...this.$refs.report_card].map(card => card.downloadableBlobs)
+        .forEach((blobs) => {
+          ['maskedImg', 'friendlyReport', 'nerdReport'].forEach((fileItem) => {
+            zip.file(blobs[fileItem].name, blobs[fileItem].blob);
           });
-
-        // Generate zip file
-        zip.generateAsync({ type: 'blob' }).then((b) => {
-          saveAs(b, 'result.zip');
-          this.zipping = false;
         });
+
+      // Generate zip file
+      zip.generateAsync({ type: 'blob' }).then((b) => {
+        saveAs(b, 'result.zip');
+        this.zipping = false;
       });
     },
   },

--- a/front-end/nott-missing-map/src/App.vue
+++ b/front-end/nott-missing-map/src/App.vue
@@ -121,7 +121,7 @@
           </template>
 
           <!-- Bottom buttons -->
-          <v-layout row wrap class="fab-container" ma-3>
+          <v-layout row class="fab-container" ma-3>
             <!-- submit button on uploading page -->
             <v-btn v-if="uploadingPage" color="info" v-on:click="submitImg" :loading="uploading">
               Submit
@@ -390,6 +390,7 @@ export default {
    bottom: 0;
    left: 0;
    z-index: 2;
+   flex-wrap: wrap-reverse;
 }
 
 </style>

--- a/front-end/nott-missing-map/src/components/ImgPreview.vue
+++ b/front-end/nott-missing-map/src/components/ImgPreview.vue
@@ -1,7 +1,39 @@
 <template>
-  <div ref="container" >
-    <img :src="reportCard.imgUrl" ref = "i" class="comparison-image">
-    <canvas ref = "c" class="with-mask"></canvas>
+  <!-- The tooltip for Image -->
+  <div style="height: 100%;">
+    <v-tooltip :bottom="alwaysBottom || !top" :top="!alwaysBottom && top"
+      :position-x="x"
+      :position-y="y"
+      v-model="show"
+      content-class="segment-info-tooltip"
+    >
+      <template>
+        <v-layout @mousemove="onmousemove($event)">
+          <span>{{segment.name}}: </span>
+        </v-layout>
+        <v-layout row justify-space-between
+          v-for="oneClass in segment.children"
+          :key="oneClass.name"
+          @mousemove="onmousemove($event)"
+        >
+          <span class="mr-1 ml-2">{{oneClass.name}}:</span>
+          <span>{{oneClass.score.toFixed(2)}}</span>
+        </v-layout>
+      </template>
+    </v-tooltip>
+
+    <!-- Image -->
+    <v-flex ref="containerWrapper" class = "container-wrapper">
+      <div ref="container" justify-start style="width: 100%; height: 100%"
+        @mousemove="onmousemove($event); show = true"
+        @mouseover="show = true"
+        @mouseout="show = false;"
+      >
+        <img :src="reportCard.imgUrl" ref = "i" class="comparison-image">
+        <canvas ref = "c" class="with-mask"></canvas>
+      </div>
+    </v-flex>
+
   </div>
 </template>
 
@@ -13,30 +45,65 @@ export default {
   name: 'ImgPreview',
   props: {
     reportCard: Object,
+    alwaysBottom: Boolean,
   },
   data() {
-    return {};
+    return {
+      x: -1,
+      y: -1,
+      show: false,
+      segment: { children: [] },
+      top: true,
+    };
   },
   methods: {
     updateSize() {
-      this.$refs.i.style.width = `${this.$refs.c.scrollWidth}px`;
-      this.$refs.i.style.height = `${this.$refs.c.scrollHeight}px`;
+      const contW = this.$refs.containerWrapper;
+      const cont = this.$refs.container;
+      const { i, c } = this.$refs;
+      const ratio = contW.clientWidth / contW.clientHeight;
+      if (ratio > i.naturalWidth / i.naturalHeight) {
+        cont.style.width = `${contW.clientHeight * i.naturalWidth / i.naturalHeight}px`;
+      } else {
+        cont.style.height = `${contW.clientWidth * i.naturalHeight / i.naturalWidth}px`;
+      }
+      c.style.width = cont.style.width;
+      c.style.height = cont.style.height;
+
+      i.style.width = `${this.$refs.c.scrollWidth}px`;
+      i.style.height = `${this.$refs.c.scrollHeight}px`;
+    },
+    onmousemove(e) {
+      // set tooltip position
+      if (!this.show) return;
+
+      const rect = this.$refs.container.getBoundingClientRect();
+      const x = e.clientX - rect.left; // x position within the element.
+      const y = e.clientY - rect.top; // y position within the element.
+
+      const segmentW = rect.width / this.reportCard.slice.x;
+      const segmentH = rect.height / this.reportCard.slice.y;
+
+      const segmentX = Math.floor(x / segmentW);
+      const segmentY = Math.floor(y / segmentH);
+
+      if (segmentX < 0 || segmentX >= this.reportCard.slice.x
+        || segmentY < 0 || segmentY >= this.reportCard.slice.y) return;
+
+      this.segment = this.reportCard
+        .reportTree[segmentX + segmentY * this.reportCard.slice.x];
+
+      this.top = segmentY > this.reportCard.slice.y / 2;
+      this.x = rect.left + segmentW * (segmentX + 0.5);
+      this.y = rect.top + segmentH * (segmentY + (this.top ? 0 : 1));
     },
   },
 
   mounted() {
     const img = new Image();
-
     img.onload = () => {
-      const ratio = Math.min(
-        window.innerWidth / img.naturalWidth,
-        (window.innerHeight - 150) / img.naturalHeight,
-      ) * 0.8;
-      img.width = img.naturalWidth * ratio;
-      img.height = img.naturalHeight * ratio;
-
-      this.$refs.c.setAttribute('height', img.height);
-      this.$refs.c.setAttribute('width', img.width);
+      this.$refs.c.setAttribute('height', this.$refs.containerWrapper.clientHeight);
+      this.$refs.c.setAttribute('width', this.$refs.containerWrapper.clientWidth);
       drawCanvas(
         this.$refs.c,
         img,
@@ -75,6 +142,17 @@ export default {
 .with-mask {
   width: 100%;
   height: 100%;
+}
+
+.segment-info-tooltip {
+  transition: top 0.2s, left 0.2s;
+}
+
+.container-wrapper {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center
 }
 
 @import '~image-comparison/src/ImageComparison.css';

--- a/front-end/nott-missing-map/src/components/ImgPreview.vue
+++ b/front-end/nott-missing-map/src/components/ImgPreview.vue
@@ -46,6 +46,7 @@ export default {
   props: {
     reportCard: Object,
     alwaysBottom: Boolean,
+    maxHeight: { type: Number },
   },
   data() {
     return {
@@ -54,6 +55,7 @@ export default {
       show: false,
       segment: { children: [] },
       top: true,
+      maxHeightValue: undefined,
     };
   },
   methods: {
@@ -61,14 +63,15 @@ export default {
       const contW = this.$refs.containerWrapper;
       const cont = this.$refs.container;
       const { i, c } = this.$refs;
-      const ratio = contW.clientWidth / contW.clientHeight;
+      const contWHeight = Math.min(this.maxHeightValue, contW.clientHeight);
+      const ratio = contW.clientWidth / contWHeight;
       if (ratio > i.naturalWidth / i.naturalHeight) {
-        cont.style.width = `${contW.clientHeight * i.naturalWidth / i.naturalHeight}px`;
+        cont.style.width = `${contWHeight * i.naturalWidth / i.naturalHeight}px`;
       } else {
         cont.style.height = `${contW.clientWidth * i.naturalHeight / i.naturalWidth}px`;
       }
-      c.style.width = cont.style.width;
-      c.style.height = cont.style.height;
+      c.style.width = '100%';
+      c.style.height = '100%';
 
       i.style.width = `${this.$refs.c.scrollWidth}px`;
       i.style.height = `${this.$refs.c.scrollHeight}px`;
@@ -100,10 +103,12 @@ export default {
   },
 
   mounted() {
+    this.maxHeightValue = this.maxHeight;
+    if (!this.maxHeightValue) this.maxHeightValue = (window.innerHeight - 300);
     const img = new Image();
     img.onload = () => {
-      this.$refs.c.setAttribute('height', this.$refs.containerWrapper.clientHeight);
-      this.$refs.c.setAttribute('width', this.$refs.containerWrapper.clientWidth);
+      this.$refs.c.setAttribute('height', this.$refs.i.naturalHeight);
+      this.$refs.c.setAttribute('width', this.$refs.i.naturalWidth);
       drawCanvas(
         this.$refs.c,
         img,
@@ -126,6 +131,7 @@ export default {
           },
         ],
       });
+
       this.updateSize();
     };
     img.src = this.reportCard.imgUrl;

--- a/front-end/nott-missing-map/src/components/ReportCard.vue
+++ b/front-end/nott-missing-map/src/components/ReportCard.vue
@@ -4,7 +4,9 @@
       <v-card>
         <v-card-title primary-title>
           <v-flex xs6 sm12 lg6 justify-start pa-1>
-            <ImgPreview :reportCard="ThisReportCard" alwaysBottom/>
+            <ImgPreview :reportCard="ThisReportCard" :maxHeight="300" alwaysBottom/>
+            <div style="max-height:300px">
+            </div>
             <canvas ref = "full" id="full"></canvas>
           </v-flex>
 

--- a/front-end/nott-missing-map/src/components/ReportCard.vue
+++ b/front-end/nott-missing-map/src/components/ReportCard.vue
@@ -11,12 +11,15 @@
             content-class="segment-info-tooltip"
           >
             <template>
+              <v-layout @mousemove="onmousemove($event)">
+                <span>{{dynamicTooltip.segment.name}}: </span>
+              </v-layout>
               <v-layout row justify-space-between
                 v-for="oneClass in dynamicTooltip.segment.children"
                 :key="oneClass.name"
                 @mousemove="onmousemove($event)"
               >
-                <span class="mr-1">{{oneClass.name}}:</span>
+                <span class="mr-1 ml-2">{{oneClass.name}}:</span>
                 <span>{{oneClass.score.toFixed(2)}}</span>
               </v-layout>
             </template>

--- a/front-end/nott-missing-map/src/functions/upload.js
+++ b/front-end/nott-missing-map/src/functions/upload.js
@@ -120,7 +120,6 @@ export default (slice, file, progress) => {
           const re = /(_[1-9]?[0-9]+)(?!.*[0-9])/;
           // remember to slice out the first "_" character
           const segmentNum = i => parseInt(re.exec(i.image)[0].slice(1), 10);
-          console.log(s1, segmentNum(s1));
           return segmentNum(s1) - segmentNum(s2);
         }))
         .reduce((arr1, arr2) => arr1.concat(arr2))


### PR DESCRIPTION
1. JSON report is given together with the text report.
2. The reports are now given separately and are now given when clicking the download button on individual report cards.
3. Add d tooltips for segments.
4. Add instruction button on the top right corner with links to our full user report, software documentation, and GitHub repo.